### PR TITLE
feat: allow optional curtain percentages

### DIFF
--- a/esp-smarthome-wifi-mesh-fw/components/protobuf/smarthome-protobuf/proto/v1/client-message.proto
+++ b/esp-smarthome-wifi-mesh-fw/components/protobuf/smarthome-protobuf/proto/v1/client-message.proto
@@ -5,6 +5,7 @@ syntax = "proto3";
 option java_package         = "com.sunshine.smarthome.server.message.protobuf";
 option java_outer_classname = "ClientBuf";
 import "common-message.proto";
+import "google/protobuf/wrappers.proto";
 
 /***** Messages ClientRequest/ClientResponse của các Devices *****/
 /* Thiết bị kết nối wifi Devices */
@@ -197,15 +198,15 @@ message UpdateSwitcherState {
 /* Thiết bị rèm cửa */
 // Nhận được lệnh điều khiển rèm cửa
 message CurtainSwitcherClientRequest {
-  uint32 percentIn  = 1;  // Phần trăm hướng trong
-  uint32 percentOut = 2;  // Phần trăm hướng ngoài
+  google.protobuf.UInt32Value percentIn  = 1;  // Phần trăm hướng trong
+  google.protobuf.UInt32Value percentOut = 2;  // Phần trăm hướng ngoài
   string hardwareId = 3;  // hardwareId của thiết bị
 }
 
 // Phản hồi lệnh điều khiển rèm cửa
 message CurtainSwitcherClientResponse {
-  uint32 percentIn  = 1;  // Phần trăm hướng trong
-  uint32 percentOut = 2;  // Phần trăm hướng ngoài
+  google.protobuf.UInt32Value percentIn  = 1;  // Phần trăm hướng trong
+  google.protobuf.UInt32Value percentOut = 2;  // Phần trăm hướng ngoài
   string deviceId   = 3;  // deviceId của thiết bị
 
   StatusCode statusCode = 1000;
@@ -378,8 +379,8 @@ message SwitcherOnChangedClientResponse {
 // Dùng cho trường công tắc rèm cửa chủ động gửi trạng thái lên server
 // Phản hồi thông tin thay đổi trạng thái của điều hòa runtime
 message CurtainSwitcherOnChangedClientResponse {
-  uint32 percentIn  = 1;  // Phần trăm hướng trong
-  uint32 percentOut = 2;  // Phần trăm hướng ngoài
+  google.protobuf.UInt32Value percentIn  = 1;  // Phần trăm hướng trong
+  google.protobuf.UInt32Value percentOut = 2;  // Phần trăm hướng ngoài
   string deviceId   = 3;  // deviceId của thiết bị
 
   StatusCode statusCode = 1000;
@@ -500,8 +501,8 @@ message TouchPanelControlSwitchOnChangedClientResponse {
 message TouchPanelControlCurtainSwitchOnChangedClientResponse {
   string touchPanelId         = 1;
   string curtainSwitcherId    = 2;
-  uint32 percentIn            = 3;
-  uint32 percentOut           = 4;
+  google.protobuf.UInt32Value percentIn            = 3;
+  google.protobuf.UInt32Value percentOut           = 4;
 
   StatusCode statusCode = 1000;
 }

--- a/esp-smarthome-wifi-mesh-fw/components/protobuf/smarthome-protobuf/proto/v1/server-message.proto
+++ b/esp-smarthome-wifi-mesh-fw/components/protobuf/smarthome-protobuf/proto/v1/server-message.proto
@@ -8,6 +8,7 @@ option java_outer_classname = "ServerBuf";
 /***** Import messages *****/
 import "common-message.proto";
 import "client-message.proto";
+import "google/protobuf/wrappers.proto";
 
 /***** Messages Request/Response của Server *****/
 /* Đăng nhập hệ thống */
@@ -703,16 +704,16 @@ message GetCurtainSwitcherStateServerRequest {
 
 // Phản hồi thông tin state của rèm cửa
 message GetCurtainSwitcherStateServerResponse {
-  uint32 percentIn      = 1;  // Phần trăm hướng trong
-  uint32 percentOut     = 2;  // Phần trăm hướng ngoài
+  google.protobuf.UInt32Value percentIn      = 1;  // Phần trăm hướng trong
+  google.protobuf.UInt32Value percentOut     = 2;  // Phần trăm hướng ngoài
   StatusCode statusCode = 1000;
 }
 
 // Nhận được lệnh điều khiển rèm cửa
 message CurtainSwitcherServerRequest {
   string deviceId   = 1;
-  uint32 percentIn  = 2;  // Phần trăm hướng trong
-  uint32 percentOut = 3;  // Phần trăm hướng ngoài
+  google.protobuf.UInt32Value percentIn  = 2;  // Phần trăm hướng trong
+  google.protobuf.UInt32Value percentOut = 3;  // Phần trăm hướng ngoài
 }
 
 // Phản hồi lệnh điều khiển rèm cửa
@@ -1468,8 +1469,8 @@ message SwitcherOnChangedServerResponse {
 // Phản hồi trạng thái rèm cửa runtime
 message CurtainSwitcherOnChangedServerResponse {
   string deviceId       = 1;  // Id của thiết bị để mobile update trạng thái
-  uint32 percentIn      = 2;  // Phần trăm hướng trong
-  uint32 percentOut     = 3;  // Phần trăm hướng ngoài
+  google.protobuf.UInt32Value percentIn      = 2;  // Phần trăm hướng trong
+  google.protobuf.UInt32Value percentOut     = 3;  // Phần trăm hướng ngoài
   StatusCode statusCode = 1000;
 }
 
@@ -2030,8 +2031,8 @@ message TouchPanelUpdateSwitcherServerRequest {
 message TouchPanelControlCurtainSwitcherServerRequest {
   string touchPanelId               = 1;
   string curtainSwitcherId          = 2;
-  uint32 percentIn                  = 3;
-  uint32 percentOut                 = 4;
+  google.protobuf.UInt32Value percentIn                  = 3;
+  google.protobuf.UInt32Value percentOut                 = 4;
 }
 
 message TouchPanelUpdateCurtainSwitcherServerRequest {

--- a/esp-smarthome-wifi-mesh-fw/main/periph_monitor.c
+++ b/esp-smarthome-wifi-mesh-fw/main/periph_monitor.c
@@ -837,7 +837,15 @@ esp_err_t periph_monitor_process_events(audio_event_iface_msg_t *event, void *co
             } else if (event->cmd == PERIPH_MESH_CURTAIN_REQUEST) {
                 LOGI(TAG, "PERIPH_MESH_CURTAIN_REQUEST");
                 CurtainSwitcherClientRequest *curtainReq = (CurtainSwitcherClientRequest *)event->data;
-                motor_pos_t                   resp_pos = periph_motor_set_pos(periph_monitor->motor_periph, curtainReq->percentin, curtainReq->percentout);
+                int                           in_val  = -1;
+                int                           out_val = -1;
+                if (curtainReq->percentin) {
+                    in_val = curtainReq->percentin->value;
+                }
+                if (curtainReq->percentout) {
+                    out_val = curtainReq->percentout->value;
+                }
+                motor_pos_t resp_pos = periph_motor_set_pos(periph_monitor->motor_periph, in_val, out_val);
                 esp_periph_send_event(g_periph_monitor, MONITOR_CURTAIN_EVENT, (void *)&resp_pos.in_pos, (int)resp_pos.out_pos);
             } else if (event->cmd == PERIPH_MESH_PARENT_CONNECTED || event->cmd == PERIPH_MESH_WS_DISCONNECTED) {
                 periph_monitor->next_state = MONITOR_WAITING_WEBSOCKET;

--- a/esp-smarthome-wifi-mesh-fw/main/periph_motor_drycontact.c
+++ b/esp-smarthome-wifi-mesh-fw/main/periph_motor_drycontact.c
@@ -163,17 +163,21 @@ motor_pos_t periph_motor_drycontact_set_pos(motor_drycontact_handle_t motor_dryc
         motor_drycontact_control(single_a_pin, single_b_pin, LOW, val_in > 50 ? HIGH : LOW);
         LOGI(TAG, "Single curtain position: %d", motor_drycontact_handle->position.in_pos);
     } else if (motor_drycontact_handle->hw.drycontact.type == MOTOR_TYPE_DOUBLE) {
-        motor_drycontact_handle->position.in_pos = val_in > 50 ? 100 : 0;
-        motor_drycontact_handle->position.out_pos = val_out > 50 ? 100 : 0;
-        if (val_in > 50)
-            periph_motor_drycontact_control(motor_drycontact_handle, MOTOR_IN_CTRL_OPEN);
-        else
-            periph_motor_drycontact_control(motor_drycontact_handle, MOTOR_IN_CTRL_CLOSE);
-        vTaskDelay(200 / portTICK_PERIOD_MS);
-        if (val_out > 50)
-            periph_motor_drycontact_control(motor_drycontact_handle, MOTOR_OUT_CTRL_OPEN);
-        else
-            periph_motor_drycontact_control(motor_drycontact_handle, MOTOR_OUT_CTRL_CLOSE);
+        if (val_in >= 0) {
+            motor_drycontact_handle->position.in_pos = val_in > 50 ? 100 : 0;
+            if (val_in > 50)
+                periph_motor_drycontact_control(motor_drycontact_handle, MOTOR_IN_CTRL_OPEN);
+            else
+                periph_motor_drycontact_control(motor_drycontact_handle, MOTOR_IN_CTRL_CLOSE);
+            vTaskDelay(200 / portTICK_PERIOD_MS);
+        }
+        if (val_out >= 0) {
+            motor_drycontact_handle->position.out_pos = val_out > 50 ? 100 : 0;
+            if (val_out > 50)
+                periph_motor_drycontact_control(motor_drycontact_handle, MOTOR_OUT_CTRL_OPEN);
+            else
+                periph_motor_drycontact_control(motor_drycontact_handle, MOTOR_OUT_CTRL_CLOSE);
+        }
         LOGI(TAG, "Double curtain position: %d (in) , %d (out)", motor_drycontact_handle->position.in_pos, motor_drycontact_handle->position.out_pos);
     }
     return motor_drycontact_handle->position;

--- a/esp-smarthome-wifi-mesh-fw/tests/stubs/app_utility.h
+++ b/esp-smarthome-wifi-mesh-fw/tests/stubs/app_utility.h
@@ -1,0 +1,8 @@
+#ifndef APP_UTILITY_H
+#define APP_UTILITY_H
+#include <stdint.h>
+#define LOGI(tag, fmt, ...)
+#define LOGE(tag, fmt, ...)
+#define LOGD(tag, fmt, ...)
+#define LOGW(tag, fmt, ...)
+#endif

--- a/esp-smarthome-wifi-mesh-fw/tests/stubs/driver/gpio.h
+++ b/esp-smarthome-wifi-mesh-fw/tests/stubs/driver/gpio.h
@@ -1,0 +1,16 @@
+#ifndef DRIVER_GPIO_H
+#define DRIVER_GPIO_H
+#include <stdint.h>
+typedef int gpio_num_t;
+typedef struct {
+    int intr_type;
+    int mode;
+    uint64_t pin_bit_mask;
+    int pull_down_en;
+    int pull_up_en;
+} gpio_config_t;
+#define GPIO_INTR_DISABLE 0
+#define GPIO_MODE_OUTPUT 0
+int gpio_config(const gpio_config_t *cfg);
+int gpio_set_level(gpio_num_t pin, int level);
+#endif

--- a/esp-smarthome-wifi-mesh-fw/tests/stubs/esp_err.h
+++ b/esp-smarthome-wifi-mesh-fw/tests/stubs/esp_err.h
@@ -1,0 +1,6 @@
+#ifndef ESP_ERR_H
+#define ESP_ERR_H
+typedef int esp_err_t;
+#define ESP_OK 0
+#define ESP_FAIL -1
+#endif

--- a/esp-smarthome-wifi-mesh-fw/tests/stubs/esp_log.h
+++ b/esp-smarthome-wifi-mesh-fw/tests/stubs/esp_log.h
@@ -1,0 +1,5 @@
+#ifndef ESP_LOG_H
+#define ESP_LOG_H
+#define ESP_LOGI(tag, fmt, ...)
+#define ESP_LOGE(tag, fmt, ...)
+#endif

--- a/esp-smarthome-wifi-mesh-fw/tests/stubs/esp_peripherals.h
+++ b/esp-smarthome-wifi-mesh-fw/tests/stubs/esp_peripherals.h
@@ -1,0 +1,5 @@
+#ifndef ESP_PERIPHERALS_H
+#define ESP_PERIPHERALS_H
+typedef void* esp_periph_handle_t;
+#define PERIPH_MEM_CHECK(TAG, a, action) if (!(a)) { action; }
+#endif

--- a/esp-smarthome-wifi-mesh-fw/tests/stubs/esp_system.h
+++ b/esp-smarthome-wifi-mesh-fw/tests/stubs/esp_system.h
@@ -1,0 +1,3 @@
+#ifndef ESP_SYSTEM_H
+#define ESP_SYSTEM_H
+#endif

--- a/esp-smarthome-wifi-mesh-fw/tests/stubs/freertos/FreeRTOS.h
+++ b/esp-smarthome-wifi-mesh-fw/tests/stubs/freertos/FreeRTOS.h
@@ -1,0 +1,6 @@
+#ifndef FREERTOS_FREERTOS_H
+#define FREERTOS_FREERTOS_H
+#include <stdint.h>
+typedef int BaseType_t;
+#define portTICK_PERIOD_MS 1
+#endif

--- a/esp-smarthome-wifi-mesh-fw/tests/stubs/freertos/queue.h
+++ b/esp-smarthome-wifi-mesh-fw/tests/stubs/freertos/queue.h
@@ -1,0 +1,3 @@
+#ifndef FREERTOS_QUEUE_H
+#define FREERTOS_QUEUE_H
+#endif

--- a/esp-smarthome-wifi-mesh-fw/tests/stubs/freertos/task.h
+++ b/esp-smarthome-wifi-mesh-fw/tests/stubs/freertos/task.h
@@ -1,0 +1,4 @@
+#ifndef FREERTOS_TASK_H
+#define FREERTOS_TASK_H
+static inline void vTaskDelay(int x) { (void)x; }
+#endif

--- a/esp-smarthome-wifi-mesh-fw/tests/stubs/sdkconfig.h
+++ b/esp-smarthome-wifi-mesh-fw/tests/stubs/sdkconfig.h
@@ -1,0 +1,3 @@
+#ifndef SDKCONFIG_H
+#define SDKCONFIG_H
+#endif

--- a/esp-smarthome-wifi-mesh-fw/tests/test_motor_drycontact.c
+++ b/esp-smarthome-wifi-mesh-fw/tests/test_motor_drycontact.c
@@ -1,0 +1,42 @@
+#include <assert.h>
+#include "periph_motor.h"
+#include "driver/gpio.h"
+
+int gpio_in_calls = 0;
+int gpio_out_calls = 0;
+
+int gpio_config(const gpio_config_t *cfg) { return 0; }
+int gpio_set_level(gpio_num_t pin, int level) {
+    if (pin == 1 || pin == 2) gpio_in_calls++;
+    if (pin == 3 || pin == 4) gpio_out_calls++;
+    return 0;
+}
+
+int main() {
+    motor_drycontact_t handle = {0};
+    handle.hw.drycontact.type = MOTOR_TYPE_DOUBLE;
+    handle.hw.drycontact.motor_drycontact_in_conn.a_pin = 1;
+    handle.hw.drycontact.motor_drycontact_in_conn.b_pin = 2;
+    handle.hw.drycontact.motor_drycontact_out_conn.a_pin = 3;
+    handle.hw.drycontact.motor_drycontact_out_conn.b_pin = 4;
+
+    // Test moving only inner curtain
+    handle.position.in_pos = 0; handle.position.out_pos = 0;
+    gpio_in_calls = gpio_out_calls = 0;
+    periph_motor_drycontact_set_pos(&handle, 100, -1);
+    assert(handle.position.in_pos == 100);
+    assert(handle.position.out_pos == 0);
+    assert(gpio_in_calls > 0);
+    assert(gpio_out_calls == 0);
+
+    // Test moving only outer curtain
+    handle.position.in_pos = 100; handle.position.out_pos = 0;
+    gpio_in_calls = gpio_out_calls = 0;
+    periph_motor_drycontact_set_pos(&handle, -1, 100);
+    assert(handle.position.in_pos == 100);
+    assert(handle.position.out_pos == 100);
+    assert(gpio_in_calls == 0);
+    assert(gpio_out_calls > 0);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- allow curtain percent fields to be optional in client/server protobuf messages
- handle missing curtain percentages with sentinel values
- ignore sentinel values in dry contact motor control
- add simulation test verifying single-curtain operation

## Testing
- `gcc -I tests/stubs -I tests/stubs/driver -I tests/stubs/freertos -I main/include tests/test_motor_drycontact.c main/periph_motor_drycontact.c -o tests/test_motor_drycontact`
- `./tests/test_motor_drycontact`
- `bash protobuf_build.sh` *(fails: google/protobuf/wrappers.proto: File not found; protoc-gen-c missing)*
- `protoc --dart_out=./proto_message_dart/lib/messages -I ./proto/v1 ./proto/v1/client-message.proto` *(fails: protoc-gen-dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895cd26c0d483339f66e14dcc033912