### PR TITLE
Validate motor position bounds

### DIFF
--- a/esp-smarthome-wifi-mesh-fw/main/periph_motor.c
+++ b/esp-smarthome-wifi-mesh-fw/main/periph_motor.c
@@ -91,7 +91,7 @@ motor_pos_t periph_motor_set_pos(esp_periph_handle_t periph_motor, int val_in, i
     motor_pos_t resp_pos = {0, 0};
     VALIDATE_MOTOR(periph_motor, resp_pos);
     periph_motor_t *motor_handle = esp_periph_get_data(periph_motor);
-    if ((val_in < 0 && val_in > 100) || (val_out < 0 && val_out > 100)) {
+    if (val_in < 0 || val_in > 100 || val_out < 0 || val_out > 100) {
         ESP_LOGE(TAG, "Position values error!!!");
         return resp_pos;
     }


### PR DESCRIPTION
## Summary
- fix motor position range check to reject any values outside 0-100

## Testing
- `gcc /tmp/test_motor.c -o /tmp/test_motor && /tmp/test_motor`
- `bash setup_env.sh` *(fails: No such file or directory)*
- `idf.py build` *(fails: command not found)*
- `git clone --depth 1 https://github.com/espressif/esp-idf.git esp-smarthome-wifi-mesh-fw/esp-idf` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6895d08be6c8833386e4ccb38f3d1829