### PR TITLE
Handle errors in dry contact motor control

### DIFF
--- a/esp-smarthome-wifi-mesh-fw/main/periph_motor_drycontact.c
+++ b/esp-smarthome-wifi-mesh-fw/main/periph_motor_drycontact.c
@@ -148,48 +148,76 @@ esp_err_t periph_motor_drycontact_control(motor_drycontact_handle_t motor_drycon
             vTaskDelay(200 / portTICK_PERIOD_MS);
         }
     }
+    esp_err_t ret = ESP_OK;
     switch (control) {
         case MOTOR_SINGLE_CTRL_OPEN:
             LOGI(TAG, "Open single curtain!");
-            motor_drycontact_control(single_a_pin, single_b_pin, LOW, LOW);
+            ret = motor_drycontact_control(single_a_pin, single_b_pin, LOW, LOW);
+            if (ret != ESP_OK) {
+                return ESP_FAIL;
+            }
             motor_drycontact_handle->position.in_pos = 100;
             break;
         case MOTOR_SINGLE_CTRL_CLOSE:
             LOGI(TAG, "Close single curtain!");
-            motor_drycontact_control(single_a_pin, single_b_pin, LOW, HIGH);
+            ret = motor_drycontact_control(single_a_pin, single_b_pin, LOW, HIGH);
+            if (ret != ESP_OK) {
+                return ESP_FAIL;
+            }
             motor_drycontact_handle->position.in_pos = 0;
             break;
         case MOTOR_SINGLE_CTRL_STOP:
             LOGI(TAG, "Stop single curtain!");
-            motor_drycontact_control(single_a_pin, single_b_pin, HIGH, LOW);
+            ret = motor_drycontact_control(single_a_pin, single_b_pin, HIGH, LOW);
+            if (ret != ESP_OK) {
+                return ESP_FAIL;
+            }
             break;
         case MOTOR_IN_CTRL_OPEN:
             LOGI(TAG, "Open in curtain!");
-            motor_drycontact_control(curtain_in_a_pin, curtain_in_b_pin, LOW, LOW);
+            ret = motor_drycontact_control(curtain_in_a_pin, curtain_in_b_pin, LOW, LOW);
+            if (ret != ESP_OK) {
+                return ESP_FAIL;
+            }
             motor_drycontact_handle->position.in_pos = 100;
             break;
         case MOTOR_IN_CTRL_CLOSE:
             LOGI(TAG, "Close in curtain!");
-            motor_drycontact_control(curtain_in_a_pin, curtain_in_b_pin, HIGH, LOW);
+            ret = motor_drycontact_control(curtain_in_a_pin, curtain_in_b_pin, HIGH, LOW);
+            if (ret != ESP_OK) {
+                return ESP_FAIL;
+            }
             motor_drycontact_handle->position.in_pos = 0;
             break;
         case MOTOR_IN_CTRL_STOP:
             LOGI(TAG, "Stop in curtain!");
-            motor_drycontact_control(curtain_in_a_pin, curtain_in_b_pin, LOW, HIGH);
+            ret = motor_drycontact_control(curtain_in_a_pin, curtain_in_b_pin, LOW, HIGH);
+            if (ret != ESP_OK) {
+                return ESP_FAIL;
+            }
             break;
         case MOTOR_OUT_CTRL_OPEN:
             LOGI(TAG, "Open out curtain!");
-            motor_drycontact_control(curtain_out_a_pin, curtain_out_b_pin, LOW, HIGH);
+            ret = motor_drycontact_control(curtain_out_a_pin, curtain_out_b_pin, LOW, HIGH);
+            if (ret != ESP_OK) {
+                return ESP_FAIL;
+            }
             motor_drycontact_handle->position.out_pos = 100;
             break;
         case MOTOR_OUT_CTRL_CLOSE:
             LOGI(TAG, "Close out curtain!");
-            motor_drycontact_control(curtain_out_a_pin, curtain_out_b_pin, HIGH, LOW);
+            ret = motor_drycontact_control(curtain_out_a_pin, curtain_out_b_pin, HIGH, LOW);
+            if (ret != ESP_OK) {
+                return ESP_FAIL;
+            }
             motor_drycontact_handle->position.out_pos = 0;
             break;
         case MOTOR_OUT_CTRL_STOP:
             LOGI(TAG, "Stop out curtain!");
-            motor_drycontact_control(curtain_out_a_pin, curtain_out_b_pin, LOW, LOW);
+            ret = motor_drycontact_control(curtain_out_a_pin, curtain_out_b_pin, LOW, LOW);
+            if (ret != ESP_OK) {
+                return ESP_FAIL;
+            }
             break;
         default:
             break;


### PR DESCRIPTION
## Summary
- Check `motor_drycontact_control` return values and propagate `ESP_FAIL`
- Add test stub to simulate GPIO failure and ensure `last_control` remains unchanged on errors

## Testing
- `gcc test_motor_drycontact.c ../main/periph_motor_drycontact.c -I stubs -I ../main/include -o test_motor_drycontact`
- `./test_motor_drycontact`


------
https://chatgpt.com/codex/tasks/task_e_689c758774208333b29742dbb20ef69e