### PR TITLE
Validate motor type before processing control

### DIFF
--- a/esp-smarthome-wifi-mesh-fw/main/periph_motor_drycontact.c
+++ b/esp-smarthome-wifi-mesh-fw/main/periph_motor_drycontact.c
@@ -105,6 +105,23 @@ esp_err_t periph_motor_drycontact_control(motor_drycontact_handle_t motor_drycon
     gpio_num_t curtain_out_a_pin = motor_drycontact_handle->hw.drycontact.motor_drycontact_out_conn.a_pin;
     gpio_num_t curtain_out_b_pin = motor_drycontact_handle->hw.drycontact.motor_drycontact_out_conn.b_pin;
 
+    motor_type_t motor_type = motor_drycontact_handle->hw.drycontact.type;
+    bool single_cmd = control == MOTOR_SINGLE_CTRL_OPEN || control == MOTOR_SINGLE_CTRL_CLOSE ||
+                      control == MOTOR_SINGLE_CTRL_STOP;
+    bool double_cmd = control == MOTOR_IN_CTRL_OPEN || control == MOTOR_IN_CTRL_CLOSE ||
+                      control == MOTOR_IN_CTRL_STOP || control == MOTOR_OUT_CTRL_OPEN ||
+                      control == MOTOR_OUT_CTRL_CLOSE || control == MOTOR_OUT_CTRL_STOP;
+    if (control != MOTOR_CTRL_NONE) {
+        if (motor_type == MOTOR_TYPE_SINGLE && !single_cmd) {
+            LOGW(TAG, "Unsupported control %d for single motor", control);
+            return ESP_FAIL;
+        }
+        if (motor_type == MOTOR_TYPE_DOUBLE && !double_cmd) {
+            LOGW(TAG, "Unsupported control %d for double motor", control);
+            return ESP_FAIL;
+        }
+    }
+
     bool same = motor_drycontact_handle->last_control == control &&
                  (control == MOTOR_SINGLE_CTRL_OPEN || control == MOTOR_SINGLE_CTRL_CLOSE ||
                   control == MOTOR_IN_CTRL_OPEN || control == MOTOR_IN_CTRL_CLOSE ||

--- a/esp-smarthome-wifi-mesh-fw/tests/test_motor_drycontact.c
+++ b/esp-smarthome-wifi-mesh-fw/tests/test_motor_drycontact.c
@@ -73,6 +73,19 @@ int main() {
     assert(gpio_in_calls == 8);
     assert(handle.last_control == MOTOR_IN_CTRL_STOP);
 
+    // Test unsupported command for double motor
+    handle.last_control = MOTOR_CTRL_NONE;
+    assert(periph_motor_drycontact_control(&handle, MOTOR_SINGLE_CTRL_OPEN) == ESP_FAIL);
+    assert(handle.last_control == MOTOR_CTRL_NONE);
+
+    // Test unsupported command for single motor
+    motor_drycontact_t single = (motor_drycontact_t){0};
+    single.hw.drycontact.type = MOTOR_TYPE_SINGLE;
+    single.hw.drycontact.motor_drycontact_single_conn.a_pin = 5;
+    single.hw.drycontact.motor_drycontact_single_conn.b_pin = 6;
+    single.last_control = MOTOR_CTRL_NONE;
+    assert(periph_motor_drycontact_control(&single, MOTOR_IN_CTRL_OPEN) == ESP_FAIL);
+    assert(single.last_control == MOTOR_CTRL_NONE);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- ensure motor drycontact control commands match configured motor type
- warn and fail on unsupported commands
- add tests for invalid commands

## Testing
- `gcc -I tests/stubs -I main/include tests/test_motor_drycontact.c main/periph_motor_drycontact.c -o tests/test_motor_drycontact && tests/test_motor_drycontact && echo TESTS_OK`


------
https://chatgpt.com/codex/tasks/task_e_689c758a7acc8333a817e7172bc02fc1