### PR TITLE
Allow partial curtain updates

### DIFF
--- a/esp-smarthome-wifi-mesh-fw/main/include/periph_motor.h
+++ b/esp-smarthome-wifi-mesh-fw/main/include/periph_motor.h
@@ -95,6 +95,13 @@ typedef motor_drycontact_t* motor_drycontact_handle_t;
 
 esp_periph_handle_t periph_motor_init(periph_motor_cfg_t* motor_cfg);
 esp_err_t periph_motor_control(esp_periph_handle_t periph_motor, motor_control_t control);
+
+/**
+ * @brief Set curtain positions.
+ *
+ * Pass -1 for either @p val_in or @p val_out to leave that curtain unchanged.
+ * Other values must be in the range 0-100.
+ */
 motor_pos_t periph_motor_set_pos(esp_periph_handle_t periph_motor, int val_in, int val_out);
 esp_err_t periph_motor_get_pos(esp_periph_handle_t periph_motor, int* val_in, int* val_out);
 

--- a/esp-smarthome-wifi-mesh-fw/main/periph_motor.c
+++ b/esp-smarthome-wifi-mesh-fw/main/periph_motor.c
@@ -91,7 +91,7 @@ motor_pos_t periph_motor_set_pos(esp_periph_handle_t periph_motor, int val_in, i
     motor_pos_t resp_pos = {0, 0};
     VALIDATE_MOTOR(periph_motor, resp_pos);
     periph_motor_t *motor_handle = esp_periph_get_data(periph_motor);
-    if (val_in < 0 || val_in > 100 || val_out < 0 || val_out > 100) {
+    if (val_in < -1 || val_in > 100 || val_out < -1 || val_out > 100) {
         ESP_LOGE(TAG, "Position values error!!!");
         return resp_pos;
     }

--- a/esp-smarthome-wifi-mesh-fw/tests/stubs/esp_peripherals.h
+++ b/esp-smarthome-wifi-mesh-fw/tests/stubs/esp_peripherals.h
@@ -1,5 +1,18 @@
 #ifndef ESP_PERIPHERALS_H
 #define ESP_PERIPHERALS_H
+
+#include <stdbool.h>
+
 typedef void* esp_periph_handle_t;
+typedef struct { int dummy; } audio_event_iface_msg_t;
+
 #define PERIPH_MEM_CHECK(TAG, a, action) if (!(a)) { action; }
+#define PERIPH_ID_MAX 0
+
+esp_periph_handle_t esp_periph_create(int id, const char *name);
+void esp_periph_set_data(esp_periph_handle_t periph, void *data);
+void *esp_periph_get_data(esp_periph_handle_t periph);
+void esp_periph_set_function(esp_periph_handle_t periph, void *init, void *run, void *destroy);
+bool esp_periph_validate(esp_periph_handle_t periph, int id);
+
 #endif

--- a/esp-smarthome-wifi-mesh-fw/tests/stubs/freertos/FreeRTOS.h
+++ b/esp-smarthome-wifi-mesh-fw/tests/stubs/freertos/FreeRTOS.h
@@ -3,4 +3,5 @@
 #include <stdint.h>
 typedef int BaseType_t;
 #define portTICK_PERIOD_MS 1
+#define portTICK_RATE_MS portTICK_PERIOD_MS
 #endif

--- a/esp-smarthome-wifi-mesh-fw/tests/test_motor_drycontact.c
+++ b/esp-smarthome-wifi-mesh-fw/tests/test_motor_drycontact.c
@@ -2,6 +2,21 @@
 #include "periph_motor.h"
 #include "driver/gpio.h"
 
+#include <stdbool.h>
+
+esp_periph_handle_t esp_periph_create(int id, const char *name) { return NULL; }
+void esp_periph_set_data(esp_periph_handle_t periph, void *data) {}
+void *esp_periph_get_data(esp_periph_handle_t periph) { return periph; }
+void esp_periph_set_function(esp_periph_handle_t periph, void *init, void *run, void *destroy) {}
+bool esp_periph_validate(esp_periph_handle_t periph, int id) { return true; }
+
+typedef struct {
+    motor_type_t type;
+    motor_physic_t physic;
+    motor_uart_handle_t motor_uart_handle;
+    motor_drycontact_handle_t motor_drycontact_handle;
+} periph_motor_t;
+
 int gpio_in_calls = 0;
 int gpio_out_calls = 0;
 
@@ -20,6 +35,10 @@ int main() {
     handle.hw.drycontact.motor_drycontact_out_conn.a_pin = 3;
     handle.hw.drycontact.motor_drycontact_out_conn.b_pin = 4;
 
+    periph_motor_t periph = {0};
+    periph.physic = MOTOR_DRYCONTACT;
+    periph.motor_drycontact_handle = &handle;
+
     // Test moving only inner curtain
     handle.position.in_pos = 0; handle.position.out_pos = 0;
     gpio_in_calls = gpio_out_calls = 0;
@@ -33,6 +52,24 @@ int main() {
     handle.position.in_pos = 100; handle.position.out_pos = 0;
     gpio_in_calls = gpio_out_calls = 0;
     periph_motor_drycontact_set_pos(&handle, -1, 100);
+    assert(handle.position.in_pos == 100);
+    assert(handle.position.out_pos == 100);
+    assert(gpio_in_calls == 0);
+    assert(gpio_out_calls > 0);
+
+    // Test moving only inner curtain via public API
+    handle.position.in_pos = 0; handle.position.out_pos = 0;
+    gpio_in_calls = gpio_out_calls = 0;
+    periph_motor_set_pos((esp_periph_handle_t)&periph, 100, -1);
+    assert(handle.position.in_pos == 100);
+    assert(handle.position.out_pos == 0);
+    assert(gpio_in_calls > 0);
+    assert(gpio_out_calls == 0);
+
+    // Test moving only outer curtain via public API
+    handle.position.in_pos = 100; handle.position.out_pos = 0;
+    gpio_in_calls = gpio_out_calls = 0;
+    periph_motor_set_pos((esp_periph_handle_t)&periph, -1, 100);
     assert(handle.position.in_pos == 100);
     assert(handle.position.out_pos == 100);
     assert(gpio_in_calls == 0);


### PR DESCRIPTION
## Summary
- allow `periph_motor_set_pos` to accept `-1` for unchanged curtain positions
- document optional positions in motor header and add tests through the public API

## Testing
- `gcc -I tests/stubs -I main/include tests/test_motor_drycontact.c main/periph_motor_drycontact.c main/periph_motor.c main/periph_motor_uart.c -o test_motor`
- `./test_motor`


------
https://chatgpt.com/codex/tasks/task_e_689c75860008833381f007082d352c2f