### PR TITLE
Add control timeout timer for drycontact motor

### DIFF
--- a/esp-smarthome-wifi-mesh-fw/main/include/periph_motor.h
+++ b/esp-smarthome-wifi-mesh-fw/main/include/periph_motor.h
@@ -6,6 +6,8 @@
 #include "time.h"
 #include <sys/time.h>
 #include "esp_peripherals.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/timers.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -88,6 +90,7 @@ typedef struct {
     motor_hw_t                      hw;
     motor_pos_t                     position;
     motor_control_t                 last_control;
+    TimerHandle_t                   control_timer;
 } motor_drycontact_t;
 
 typedef motor_uart_t* motor_uart_handle_t;
@@ -109,6 +112,7 @@ esp_err_t _motor_drycontact_init(motor_drycontact_handle_t motor_drycontact_hand
 esp_err_t periph_motor_drycontact_control(motor_drycontact_handle_t motor_drycontact_handle, motor_control_t control);
 motor_pos_t periph_motor_drycontact_set_pos(motor_drycontact_handle_t motor_drycontact_handle, int val_in, int val_out);
 esp_err_t periph_motor_drycontact_get_pos(motor_drycontact_handle_t motor_drycontact_handle, int* val_in, int* val_out);
+esp_err_t periph_motor_drycontact_destroy(motor_drycontact_handle_t motor_drycontact_handle);
 
 
 #ifdef __cplusplus

--- a/esp-smarthome-wifi-mesh-fw/main/periph_motor.c
+++ b/esp-smarthome-wifi-mesh-fw/main/periph_motor.c
@@ -55,6 +55,9 @@ static esp_err_t _motor_run(esp_periph_handle_t periph, audio_event_iface_msg_t 
 static esp_err_t _motor_destroy(esp_periph_handle_t periph) {
     periph_motor_t *periph_motor = esp_periph_get_data(periph);
     vTaskDelay(2000 / portTICK_RATE_MS);
+    if (periph_motor->physic == MOTOR_DRYCONTACT && periph_motor->motor_drycontact_handle != NULL) {
+        periph_motor_drycontact_destroy(periph_motor->motor_drycontact_handle);
+    }
     free(periph_motor);
     g_periph = NULL;
     return ESP_OK;


### PR DESCRIPTION
## Summary
- add FreeRTOS timer to clear dry contact motor control after timeout
- start/reset timer on non-stop commands and clean up on destroy

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c758424d083338bad54eb85be9092