### PR TITLE
Extend double-press timeout to 10s

### DIFF
--- a/esp-smarthome-wifi-mesh-fw/main/periph_motor_drycontact.c
+++ b/esp-smarthome-wifi-mesh-fw/main/periph_motor_drycontact.c
@@ -24,7 +24,7 @@ static void motor_control_timeout_cb(TimerHandle_t timer) {
     }
 }
 
-#define TIMEOUT_CONTROL_MS 5 * 1000
+#define TIMEOUT_CONTROL_MS 10 * 1000
 #define HIGH               1
 #define LOW                0
 

--- a/esp-smarthome-wifi-mesh-fw/tests/stubs/freertos/FreeRTOS.h
+++ b/esp-smarthome-wifi-mesh-fw/tests/stubs/freertos/FreeRTOS.h
@@ -2,6 +2,8 @@
 #define FREERTOS_FREERTOS_H
 #include <stdint.h>
 typedef int BaseType_t;
+#define pdFALSE 0
+#define pdTRUE 1
 #define portTICK_PERIOD_MS 1
 #define portTICK_RATE_MS portTICK_PERIOD_MS
 #endif

--- a/esp-smarthome-wifi-mesh-fw/tests/stubs/freertos/timers.h
+++ b/esp-smarthome-wifi-mesh-fw/tests/stubs/freertos/timers.h
@@ -1,0 +1,29 @@
+#ifndef FREERTOS_TIMERS_H
+#define FREERTOS_TIMERS_H
+#include <stdint.h>
+#include "freertos/FreeRTOS.h"
+
+typedef void* TimerHandle_t;
+typedef void (*TimerCallbackFunction_t)(TimerHandle_t xTimer);
+
+static inline TimerHandle_t xTimerCreate(const char *name, uint32_t period, int auto_reload,
+                                         void *id, TimerCallbackFunction_t callback) {
+    (void)name; (void)period; (void)auto_reload; (void)callback;
+    return id;
+}
+
+static inline void *pvTimerGetTimerID(TimerHandle_t timer) { return timer; }
+
+static inline BaseType_t xTimerReset(TimerHandle_t timer, uint32_t ticks) {
+    (void)timer; (void)ticks; return 0;
+}
+
+static inline BaseType_t xTimerStop(TimerHandle_t timer, uint32_t ticks) {
+    (void)timer; (void)ticks; return 0;
+}
+
+static inline BaseType_t xTimerDelete(TimerHandle_t timer, uint32_t ticks) {
+    (void)timer; (void)ticks; return 0;
+}
+
+#endif


### PR DESCRIPTION
## Summary
- Increase dry-contact motor control timeout to 10 seconds to treat repeated commands within that window as a stop

## Testing
- `gcc -I tests/stubs -I main/include -I . tests/test_motor_drycontact.c main/periph_motor_drycontact.c main/periph_motor.c main/periph_motor_uart.c -o tests/test_motor_drycontact && tests/test_motor_drycontact && echo TEST_OK`


------
https://chatgpt.com/codex/tasks/task_e_689c7aac5724833386a6937dc1d29614