### PR TITLE
docs: add curtain switch control description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,55 @@
-source ~/esp-idf/export.sh
-//Cách đóng gói firmware để gửi cho đối tác
-//Build firmware
+# Hướng dẫn build và đóng gói firmware rèm
 
-//Vào thư mục dự án:
+Tài liệu này mô tả các bước chuẩn bị môi trường, build mã nguồn và đóng gói bộ firmware để gửi cho đối tác hoặc tự nạp vào thiết bị.
 
-cd esp-smarthome-wifi-mesh-fw
-//Nếu chưa build, chạy:
+## 1. Chuẩn bị môi trường ESP‑IDF
 
+1. Di chuyển vào thư mục dự án con:
+   ```bash
+   cd esp-smarthome-wifi-mesh-fw
+   ```
+2. Cài đặt hoặc cập nhật ESP‑IDF:
+   ```bash
+   ./setup_env.sh
+   ```
+3. Nạp biến môi trường (thực hiện mỗi khi mở terminal mới):
+   ```bash
+   source ~/esp-idf/export.sh   # hoặc ". ./setup_env.sh" nếu script đã thiết lập IDF_PATH
+   ```
+
+## 2. Build firmware
+
+```bash
 ./build.sh
-//(Sau bước này các file *.bin mã hóa sẽ nằm trong esp-flash-encrypted-and-secure-boot/build/.)
+```
+Sau bước này các file *.bin đã được mã hóa sẽ nằm trong `esp-flash-encrypted-and-secure-boot/build/`.
 
-//Thu thập file cần gửi
+## 3. Thu gom và đóng gói
 
-//Chạy script thu gom:
+1. Thu gom file cần gửi:
+   ```bash
+   ./produce.sh
+   ```
+   Script sẽ copy các file đã mã hóa (`app-encrypted.bin`, `bootloader-reflash-digest-encrypted.bin`, `ota_data_initial-encrypted.bin`, `partitions-encrypted.bin`) cùng script `flash_encrypted.sh` vào thư mục `produce/firmware/`.
 
-./produce.sh
-//Script sẽ copy các file đã mã hóa (app-encrypted.bin, bootloader-reflash-digest-encrypted.bin, ota_data_initial-encrypted.bin, partitions-encrypted.bin) và script flash_encrypted.sh vào thư mục produce/firmware/.
+2. Tạo gói nén để gửi cho đối tác:
+   ```bash
+   cd produce
+   zip -r firmware-package.zip firmware
+   ```
+   File `firmware-package.zip` chứa thư mục `firmware` cùng các file *.bin và script nạp.
 
-//Đóng gói
+## 4. Hướng dẫn đối tác nạp firmware
 
-//Tạo file nén để gửi cho đối tác:
+1. Giải nén `firmware-package.zip` và kết nối thiết bị với cổng USB.
+2. Trong thư mục `firmware` vừa giải nén, chạy:
+   ```bash
+   chmod +x flash_encrypted.sh
+   ./flash_encrypted.sh
+   ```
+   Script sẽ tự tìm cổng serial (mặc định `/dev/ttyUSB0` trên Linux) và sử dụng `esptool.py` để ghi các file nhị phân vào flash.
 
-cd produce
-zip -r firmware-package.zip firmware
-//Gửi file firmware-package.zip cho đối tác. Khi giải nén, họ sẽ nhận được thư mục firmware chứa các file *.bin và flash_encrypted.sh.
+## 5. Ghi chú
 
-//Hướng dẫn đối tác nạp
-
-//Kết nối thiết bị với cổng USB.
-
-//Trong thư mục firmware vừa giải nén, chạy:
-
-chmod +x flash_encrypted.sh
-./flash_encrypted.sh
-//Script sẽ tự tìm cổng serial (mặc định /dev/ttyUSB0 trên Linux) và sử dụng esptool.py để ghi các file nhị phân vào flash.
-
-
-Nếu chưa có ESP-IDF
-
-Install or update ESP‑IDF
-If you haven’t already:
-
-cd esp-smarthome-curtain-dry/esp-smarthome-wifi-mesh-fw
-./setup_env.sh
-Load the ESP‑IDF environment (each new terminal session):
-
-source ~/esp-idf/export.sh   # or . ./setup_env.sh if it sets IDF_PATH
-This adds idf.py and other tools to your PATH.
-
-Build again:
-
-./build.sh
+- Các bước trên yêu cầu máy tính đã cài đặt đầy đủ driver USB‑to‑Serial.
+- Nếu cần build lại ở máy khác, lặp lại bước chuẩn bị môi trường trước khi chạy `build.sh`.

--- a/esp-smarthome-wifi-mesh-fw/docs/curtain-switch-control.md
+++ b/esp-smarthome-wifi-mesh-fw/docs/curtain-switch-control.md
@@ -1,0 +1,39 @@
+# Tài liệu mô tả hoạt động của công tắc rèm
+
+## Luồng tổng quát
+
+1. **Thiết bị nhận thông điệp qua mesh**  
+   Hàm `_mesh_process_data` trong `periph_mesh.c` giải mã dữ liệu đến và lần lượt chuyển cho các bộ xử lý con, trong đó có `periph_mesh_curtain_process_message` chuyên xử lý thông điệp rèm.
+
+2. **Xử lý thông điệp rèm ở lớp mesh**  
+   - `periph_mesh_curtain_process_message` kiểm tra thông điệp `CurtainSwitcherClientRequest`.  
+     *Nếu phần cứng đích trùng khớp thiết bị hiện tại* → gửi sự kiện nội bộ để motor xử lý;  
+     *Nếu thiết bị là nút gốc* → chuyển tiếp thông điệp tới nút đích hoặc lên server.  
+   - `periph_mesh_curtain_monitor_events` lắng nghe sự kiện `MONITOR_CURTAIN_EVENT` từ lớp giám sát và đóng gói thông tin phần trăm mở/đóng để báo cáo lên mạng mesh bằng `periph_mesh_curtain_report_msg`.
+
+3. **Giám sát và kích hoạt motor**  
+   Khi nhận sự kiện `PERIPH_MESH_CURTAIN_REQUEST`, `periph_monitor.c` trích xuất giá trị phần trăm màn in/out, gọi `periph_motor_set_pos` để điều chỉnh motor và phát sự kiện `MONITOR_CURTAIN_EVENT` phản hồi trạng thái mới.
+
+4. **Điều khiển motor**
+   - API chung `periph_motor`  
+     `periph_motor_init` tạo peripheral theo cấu hình (UART hoặc dry‑contact) và gán hàm thao tác tương ứng; `periph_motor_control` và `periph_motor_set_pos` phân luồng xuống driver cụ thể.  
+     Kiểu điều khiển được định nghĩa trong `motor_control_t` với các lệnh mở/đóng/dừng cho màn đơn và màn đôi; các API cài đặt vị trí và truy vấn vị trí nằm ở cuối header.
+   - **Driver UART**  
+     `periph_motor_uart_control` gửi chuỗi lệnh UART chuẩn hóa (open/close/stop) cho từng motor, tự động dừng nếu lệnh trước ngược hướng với lệnh hiện tại và cập nhật vị trí sau khi dừng.  
+     `periph_motor_uart_set_pos` chuyển phần trăm cần đặt thành giá trị byte (đảo 100%) rồi truyền lệnh “set position” tới từng motor.
+   - **Driver dry‑contact**  
+     `periph_motor_drycontact_control` kích GPIO theo cặp tiếp điểm a/b, xử lý trường hợp lặp lại hoặc đảo chiều bằng cách chèn lệnh dừng, đồng thời cập nhật biến vị trí in/out.  
+     `periph_motor_drycontact_set_pos` ánh xạ giá trị phần trăm >50% thành “mở” và ≤50% thành “đóng”, gọi các lệnh điều khiển tương ứng cho từng màn.
+
+## Chức năng điều khiển của công tắc rèm
+
+- **Mở/đóng/dừng màn đơn**: `MOTOR_SINGLE_CTRL_OPEN`, `MOTOR_SINGLE_CTRL_CLOSE`, `MOTOR_SINGLE_CTRL_STOP`.
+- **Mở/đóng/dừng màn trái (in) hoặc phải (out)**: `MOTOR_IN_CTRL_*` và `MOTOR_OUT_CTRL_*`.
+- **Đặt vị trí phần trăm**: `periph_motor_set_pos` (đi qua UART hoặc dry‑contact); motor sẽ di chuyển rồi phản hồi vị trí thực tế lên mesh thông qua chuỗi sự kiện nêu trên.
+
+Sơ đồ điều khiển:
+
+`Client/App` → (Mesh Message) → `periph_mesh_curtain_process_message` → `periph_monitor` → `periph_motor_*` → Motor → Phản hồi vị trí → `periph_mesh_curtain_report_msg` → (Mesh Response).
+
+Tài liệu này cung cấp cái nhìn hàm‑tới‑hàm về cách firmware xử lý lệnh công tắc rèm, từ lớp mạng mesh tới driver motor, giúp việc mở rộng hoặc debug trở nên dễ dàng.
+


### PR DESCRIPTION
## Summary
- add detailed markdown document describing curtain switch control flow
- rewrite root README with clearer instructions for building, packaging, and flashing firmware

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689c81278e848333acdc5fbdbbf80802